### PR TITLE
Add support when using IDF with PlatformIO

### DIFF
--- a/IRQ-Detection/main/Kconfig.projbuild
+++ b/IRQ-Detection/main/Kconfig.projbuild
@@ -6,7 +6,7 @@ menu "Application Configuration"
 		default 46 if IDF_TARGET_ESP32S2
 		default 48 if IDF_TARGET_ESP32S3
 		default 18 if IDF_TARGET_ESP32C2
-		default 19 if IDF_TARGET_ESP32C3
+		default 21 if IDF_TARGET_ESP32C3
 		default 30 if IDF_TARGET_ESP32C6
 
 	choice DIRECTION

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_SOURCE_DIR}/.pio/libdeps/${configName}
 ```
 
 When setup correctly, PlatformIO will download the library automaticlly during build. From that moment you can include ```#include "mirf.h"```, run menuconfig and use the library.
-In case you are experimenting with the build environment, it sometimes helps to solve errors to do a full clean within PlatformIO. This deletes all downloaded files. 
+In case you are experimenting with the build environment, it sometimes helps to do a full clean within PlatformIO when faced with errors . This deletes all downloaded files. 
 
 __Note for ESP32C3__   
 For some reason, there are development boards that cannot use GPIO06, GPIO08, GPIO09, GPIO19 for SPI clock pins.   

--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ idf.py menuconfig
 idf.py flash
 ```
 
+# use with PlatformIO
+When using with PlatformIO, the paragraph above is not relevant. Within PlatfromIO the files are automatically downloaded.
+
+Add in the platform .ini file
+```lib_deps = https://github.com/nopnop2002/esp-idf-mirf
+```
+Optionally a specific tag can be added. At this moment no tag is available.
+```https://github.com/nopnop2002/esp-idf-mirf#v1.0
+```
+
+Add to the CMakeList.txt in the root of the project
+```get_filename_component(configName "${CMAKE_BINARY_DIR}" NAME)
+list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_SOURCE_DIR}/.pio/libdeps/${configName}/esp-idf-mirf/components/mirf")
+```
+
+When setup correctly, PlatformIO will download the library automaticlly during build. From that moment you can include ```#include "mirf.h"```, run menuconfig and use the library.
+In case you are experimenting with the build environment, it sometimes helps to solve errors to do a full clean within PlatformIO. This deletes all downloaded files. 
+
 __Note for ESP32C3__   
 For some reason, there are development boards that cannot use GPIO06, GPIO08, GPIO09, GPIO19 for SPI clock pins.   
 According to the ESP32C3 specifications, these pins can also be used as SPI clocks.   

--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ idf.py flash
 When using with PlatformIO, the paragraph above is not relevant. Within PlatfromIO the files are automatically downloaded.
 
 Add in the platform .ini file
-```lib_deps = https://github.com/nopnop2002/esp-idf-mirf
+```
+lib_deps = https://github.com/nopnop2002/esp-idf-mirf
 ```
 Optionally a specific tag can be added. At this moment no tag is available.
-```https://github.com/nopnop2002/esp-idf-mirf#v1.0
+```
+https://github.com/nopnop2002/esp-idf-mirf#v1.0
 ```
 
 Add to the CMakeList.txt in the root of the project
-```get_filename_component(configName "${CMAKE_BINARY_DIR}" NAME)
+```
+get_filename_component(configName "${CMAKE_BINARY_DIR}" NAME)
 list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_SOURCE_DIR}/.pio/libdeps/${configName}/esp-idf-mirf/components/mirf")
 ```
 

--- a/components/mirf/Kconfig.projbuild
+++ b/components/mirf/Kconfig.projbuild
@@ -6,7 +6,7 @@ menu "nRF24L01 Configuration"
 		default 46 if IDF_TARGET_ESP32S2
 		default 48 if IDF_TARGET_ESP32S3
 		default 18 if IDF_TARGET_ESP32C2
-		default 19 if IDF_TARGET_ESP32C3
+		default 21 if IDF_TARGET_ESP32C3
 		default 30 if IDF_TARGET_ESP32C6
 
 	config RADIO_CHANNEL

--- a/components/mirf/mirf.h
+++ b/components/mirf/mirf.h
@@ -3,6 +3,10 @@
 
 #include "driver/spi_master.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     uint8_t PTX;  //In sending mode.
     uint8_t cePin;// CE Pin controls RX / TX, default 8.
@@ -206,6 +210,10 @@ char *    Nrf24_getPALevelString(NRF24_t * dev);
 uint8_t   Nrf24_getRetransmitDelay(NRF24_t * dev);
 uint8_t   Nrf24_getChannle(NRF24_t * dev);
 uint8_t   Nrf24_getPayload(NRF24_t * dev);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MAIN_MIRF_H_ */
 

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "frameworks": "espidf",
   "platforms": "*",
   "build": {
-    "srcFilter": "-<*> +<components/mirf/*.c>",
+    "srcFilter": "-<*> +<components/mirf/>",
     "flags": [
       "-I ./components/mirf/"
     ]

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "frameworks": "espidf",
   "platforms": "*",
   "build": {
-    "srcFilter": "-<*> +<components/mirf>",
+    "srcFilter": "-<*> +<components/mirf/*.c>",
     "flags": [
       "-I ./components/mirf/"
     ]

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "frameworks": "espidf",
   "platforms": "*",
   "build": {
-    "srcFilter": "+<*> -<components/mirf>",
+    "srcFilter": "-<*> +<components/mirf>",
     "flags": [
       "-I ./components/mirf/"
     ]

--- a/library.json
+++ b/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "esp-idf-mirf",
+  "version": "1.0.0",
+  "description": "The library provides basic control of the Nordic nRF24L01/nRF24L01+ RF modules.",
+  "frameworks": "espidf",
+  "platforms": "*",
+  "build": {
+    "srcFilter": "+<*> -<components/mirf>",
+    "flags": [
+      "-I ./components/mirf/"
+    ]
+  }
+}


### PR DESCRIPTION
-Added a library.json to support building from platformIO. 
-Added support for including components/mirf/mirf.h in a cpp file. Same mechanism as IDF uses.
-Updated documentation how to library within platformIO